### PR TITLE
Fix cost function in pendulum tests

### DIFF
--- a/tests/pendulum.py
+++ b/tests/pendulum.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         theta = state[:, 0]
         theta_dt = state[:, 1]
         action = action[:, 0]
-        cost = angle_normalize(theta) ** 2 + 0.1 * theta_dt ** 2 + 0.001 * action ** 2
+        cost = angle_normalize(theta) ** 2 + 0.1 * theta_dt ** 2
         return cost
 
 

--- a/tests/pendulum_approximate.py
+++ b/tests/pendulum_approximate.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
         theta = state[:, 0]
         theta_dt = state[:, 1]
         action = action[:, 0]
-        cost = angle_normalize(theta) ** 2 + 0.1 * theta_dt ** 2 + 0.001 * action ** 2
+        cost = angle_normalize(theta) ** 2 + 0.1 * theta_dt ** 2
         return cost
 
 

--- a/tests/pendulum_approximate_continuous.py
+++ b/tests/pendulum_approximate_continuous.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
         theta = state[:, 0]
         theta_dt = state[:, 1]
         action = action[:, 0]
-        cost = angle_normalize(theta) ** 2 + 0.1 * theta_dt ** 2 + 0.001 * action ** 2
+        cost = angle_normalize(theta) ** 2 + 0.1 * theta_dt ** 2
         return cost
 
 


### PR DESCRIPTION
## What?
I've changed the cost function in pendulum tests. The cost for action should be removed in the 'running_cost(state, action)' functions. 

## Why?
As Algorithm 1 described in the [paper](https://ieeexplore.ieee.org/abstract/document/8558663),  'q(x)' represents the cost of the estimated state, and the successive term ('r * u * sigma * (u - t)' ) represents the cost of the control action.
Since the control cost is already presented in ['perturbation_cost'](https://github.com/UM-ARM-Lab/pytorch_mppi/blob/4100a6bd0f51853f3703ba3982aa3a66d1a86a48/pytorch_mppi/mppi.py#L274), the control cost in the ['running_cost()'](https://github.com/UM-ARM-Lab/pytorch_mppi/blob/4100a6bd0f51853f3703ba3982aa3a66d1a86a48/tests/pendulum.py#L59) should be removed.  'q(x)' is only depend on the state.

![algorithm1](https://user-images.githubusercontent.com/40379815/119664828-b35f9d80-be6e-11eb-998d-f8a74b6d0da3.PNG)

## How?
I've just simply deleted the control cost in the three tests scripts respectively. 

## Testing?
The pendulum examples were tested after fixing the cost functions and the results showed that the pendulums get upright faster than the previous cost functions. 


Thanks for your great work.